### PR TITLE
Migrate to AWS_ENDPOINT_URL

### DIFF
--- a/lambda-kinesis-firehose-es/lambda.py
+++ b/lambda-kinesis-firehose-es/lambda.py
@@ -9,11 +9,11 @@ logger = logging.getLogger(__name__)
 def handler(event, context):
     try:
         endpoint_url = None
-        # boto instrumentation is a pro feature (https://docs.localstack.cloud/tools/local-endpoint-injection/)
+        # Automatic boto instrumentation is a pro feature https://docs.localstack.cloud/user-guide/tools/transparent-endpoint-injection/
         # we'll do this manually here
-        if os.environ.get("LOCALSTACK_HOSTNAME"):
-            endpoint_url = "http://{}:{}".format(os.environ["LOCALSTACK_HOSTNAME"], os.environ["EDGE_PORT"])
-            
+        if os.environ.get("AWS_ENDPOINT_URL"):
+            endpoint_url = os.environ["AWS_ENDPOINT_URL"]
+
         kinesis = boto3.client(
             "kinesis", endpoint_url=endpoint_url, region_name=os.environ["AWS_REGION"], verify=False
         )
@@ -22,5 +22,5 @@ def handler(event, context):
         logger.info("Put record in stream %s.", stream_name)
     except Exception:
         logger.exception("Sending record to kinesis failed.")
-    
+
     return {"body": "Hello World!"}

--- a/sns-sqs-subscription-lambda-trigger/lambda.py
+++ b/sns-sqs-subscription-lambda-trigger/lambda.py
@@ -1,12 +1,13 @@
-import os
 import json
+import os
 
 import boto3
+
 
 def handler(event, context):
     print(event)
 
-    endpoint_url = f"http://{os.getenv("LOCALSTACK_HOSTNAME")}:{os.getenv("EDGE_PORT")}"
+    endpoint_url = os.environ["AWS_ENDPOINT_URL"]
     sqs = boto3.client("sqs", endpoint_url=endpoint_url)
 
     queue_url = os.environ['LAMBDA_RESULT_QUEUE']


### PR DESCRIPTION
Adopt `AWS_ENDPOINT_URL` as the official endpoint variable introduced by AWS.

See https://docs.localstack.cloud/user-guide/tools/transparent-endpoint-injection/

/cc repo maintainer @macnev2013 